### PR TITLE
Fix token storage consistency

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -20,7 +20,7 @@ app/
 ├── routers/
 │   ├── auth.py         # Routes for authentication (login, refresh tokens, register)
 │   ├── user.py         # Routes for user-related endpoints (get current user, admin check)
-├── security.py         # Handles encryption, token rotation, and rate-limiting
+├── security.py         # Handles hashing, token rotation, and rate-limiting
 ├── __init__.py         # App initialization
 └── main.py             # Main entry point for FastAPI application
 ```
@@ -52,12 +52,12 @@ One of the key features in ShadowID is **token rotation** for security. Each tim
 
 - **File**: `app/routers/auth.py` and `app/security.py`
 - **Key Functions**:
-  - `encrypt_data`: Encrypts refresh tokens before storing them in Redis, ensuring that sensitive tokens are protected.
+  - `encrypt_data`: Hashes refresh tokens before storing them in Redis, ensuring that sensitive tokens are protected.
   - `rotate_refresh_token`: Ensures that old tokens are deleted and replaced by new ones when they’re used to refresh an access token.
 
 #### How token-rotation Works
 
-- When a refresh token is presented, ShadowID encrypts the new refresh token before storing it in Redis.
+- When a refresh token is presented, ShadowID hashes the new refresh token before storing it in Redis.
 - Old tokens are automatically invalidated by deleting them from Redis upon refresh.
 - This adds an extra layer of security by ensuring that if a token is compromised, it won’t be usable for long.
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ No need to provide personal information like email addresses or phone numbers to
 
 ShadowID uses **OAuth2** for authentication with **JWT** to issue access tokens. These tokens are lightweight and secure, ensuring that only the right people (or anonymous identifiers) can access the system.
 
-### 3. **Refresh Tokens (with Encryption)**
+### 3. **Refresh Tokens (with Hashing)**
 
-We've taken security up a notch. **Refresh tokens** allow users to stay logged in without having to re-authenticate every few minutes. And, of course, these tokens are **encrypted** before they’re stored in Redis. Think of it as locking up the tokens in a digital vault.
+We've taken security up a notch. **Refresh tokens** allow users to stay logged in without having to re-authenticate every few minutes. For safety these tokens are stored in Redis **after being hashed**, so even if Redis is compromised the raw tokens remain secret.
 
 ### 4. **Token Rotation**
 

--- a/app/security.py
+++ b/app/security.py
@@ -1,15 +1,10 @@
 import time
 from redis import Redis
-from cryptography.fernet import Fernet
+import hashlib
 from app.services.redis_service import RedisService
 from app.config import settings
 
 r: Redis = RedisService.get_instance()
-
-# Generate a key for encryption (do this once and store it securely)
-# key = Fernet.generate_key()
-key = settings.fernet_key
-cipher_suite = Fernet(key)
 
 # Max login attempts and block duration for rate-limiting
 MAX_ATTEMPTS = settings.max_login_attempts
@@ -26,15 +21,15 @@ def get_blocked_key(identifier: str) -> str:
     return f"blocked:{identifier}"
 
 
-# Encrypt/Decrypt Functions
+# Token Hashing Functions
 def encrypt_data(data: str) -> str:
-    """Encrypts the given data using Fernet symmetric encryption."""
-    return cipher_suite.encrypt(data.encode()).decode()
+    """Return a deterministic hash of the given data."""
+    return hashlib.sha256(data.encode()).hexdigest()
 
 
 def decrypt_data(encrypted_data: str) -> str:
-    """Decrypts the given data."""
-    return cipher_suite.decrypt(encrypted_data.encode()).decode()
+    """Return the hashed data as-is (kept for backward compatibility)."""
+    return encrypted_data
 
 
 # Rate-Limiting Functions


### PR DESCRIPTION
## Summary
- hash refresh tokens instead of encrypting them
- document hashing in README and developer guide

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68483f247614832fb5d36aa7c0f5a42b